### PR TITLE
Add `no_std` and `portable-atomic` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,13 @@ repository = "https://github.com/bevyengine/atomicow"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []
+
+[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
+portable-atomic = { version = "1", default-features = false }
+portable-atomic-util = { version = "0.2.4", features = [
+  "alloc",
+] }


### PR DESCRIPTION
# Objective

- Add `no_std` support
- Add support for atomically challenged platforms using `portable-atomic`

## Solution

- Ran `cargo clippy --fix` to resolve minor issues
- Added `std` feature and gated the implementations involving `Path` and `PathBuf` behind it.
- Added `portable-atomic` as a dependency for platforms without atomic pointer support.

## Notes

The new `std` feature constitutes a breaking change, so a version bump will be required.