### PR TITLE
Write release notes and bump version to 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomicow"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.63.0"
 description = "A `Cow`-like data structure where owned data is stored inside an `Arc`."
@@ -15,6 +15,4 @@ std = []
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic = { version = "1", default-features = false }
-portable-atomic-util = { version = "0.2.4", features = [
-  "alloc",
-] }
+portable-atomic-util = { version = "0.2.4", features = ["alloc"] }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # `atomicow` Release Notes
 
+## Version 1.1
+
+- added support for `no_std` platforms: turn off `default_features` to disable the new `std` feature
+- added `AtomicCow::new_owned`
+- added a `From<Arc<T>> for AtomicCow<T>` implementation
+
 ## Version 1.0.0
 
 - initial release


### PR DESCRIPTION
A release was requested for https://github.com/bevyengine/bevy/pull/18451#discussion_r2006728229, so now is as good a time as any. Once this PR is merged I'll `cargo publish`.